### PR TITLE
Add libgmp3-dev package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 	mysql-common \
 	libmysqlclient-dev \
 	libmysqlclient18 \
+  libgmp3-dev \
 	sqlite \
 	postgresql-9.3 \
 	postgresql-9.3-dbg \


### PR DESCRIPTION
Noticed the PR. Looks like the libgmp3-dev package was required and missing. Adding that resolved the build issues that @etagwerker was seeing.

With that said, seeing between 2-3 failing tests per run, but everything else works well. Not sure if that's something else going on with Docker, or if it's something with the gem.